### PR TITLE
Validate that this folder is a git folder

### DIFF
--- a/bin/ghwd
+++ b/bin/ghwd
@@ -16,6 +16,13 @@ base_url=${base_url//git@bitbucket.org:/https:\/\/bitbucket\.org\/}
 # Fix git@gitlab.com: URLs
 base_url=${base_url//git@gitlab\.com:/https:\/\/gitlab\.com\/}
 
+# Validate that this folder is a git folder
+git branch 2>/dev/null 1>&2
+if [ $? -ne 0 ]; then
+  echo Not a git repo!
+  exit $?
+fi
+
 # Find current directory relative to .git parent
 full_path=$(pwd)
 git_base_path=$(cd ./$(git rev-parse --show-cdup); pwd)


### PR DESCRIPTION
This prevents seeing nasty cryptic errors when, by mistake, the script is run in a place where all git commands would fail.